### PR TITLE
Add various fixes for SetDeadline functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 - [SA-1463] Return error when trying to create a new socket
 - [SA-2074] Add a ReadPacket function
+- Add various fixes for SetDeadline functionality

--- a/poll.go
+++ b/poll.go
@@ -6,6 +6,7 @@ package srtgo
 */
 import "C"
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -20,19 +21,20 @@ const (
 type PollMode int
 
 const (
-	ModeRead = PollMode(iota)
+	Blah = PollMode(iota)
 	ModeWrite
+	ModeRead
 )
 
 /*
-	pollDesc contains the polling state for the associated SrtSocket
-	closing: socket is closing, reject all poll operations
-	pollErr: an error occured on the socket, indicates it's not useable anymore.
-	unblockRd: is used to unblock the poller when the socket becomes ready for io
-	rdState: polling state for read operations
-	rdDeadline: deadline in NS before poll operation times out, -1 means timedout (needs to be cleared), 0 is without timeout
-	rdSeq: sequence number protects against spurious signalling of timeouts when timer is reset.
-	rdTimer: timer used to enforce deadline.
+pollDesc contains the polling state for the associated SrtSocket
+closing: socket is closing, reject all poll operations
+pollErr: an error occured on the socket, indicates it's not useable anymore.
+unblockRd: is used to unblock the poller when the socket becomes ready for io
+rdState: polling state for read operations
+rdDeadline: deadline in NS before poll operation times out, -1 means timedout (needs to be cleared), 0 is without timeout
+rdSeq: sequence number protects against spurious signalling of timeouts when timer is reset.
+rdTimer: timer used to enforce deadline.
 */
 type pollDesc struct {
 	lock       sync.Mutex
@@ -61,8 +63,8 @@ var pdPool = sync.Pool{
 		return &pollDesc{
 			unblockRd: make(chan interface{}, 1),
 			unblockWr: make(chan interface{}, 1),
-			rdTimer:   time.NewTimer(0),
-			wdTimer:   time.NewTimer(0),
+			rdTimer:   time.NewTimer(time.Duration(time.Hour * 1)), // hack fix
+			wdTimer:   time.NewTimer(time.Duration(time.Hour * 1)), // hack fix
 		}
 	},
 }
@@ -94,6 +96,7 @@ func (pd *pollDesc) release() {
 }
 
 func (pd *pollDesc) wait(mode PollMode) error {
+	fmt.Println("[nathan debug] wait start")
 	defer pd.reset(mode)
 	if err := pd.checkPollErr(mode); err != nil {
 		return err
@@ -104,10 +107,12 @@ func (pd *pollDesc) wait(mode PollMode) error {
 	timerSeq := int64(0)
 	pd.lock.Lock()
 	if mode == ModeRead {
+		fmt.Println("[nathan debug] setting up stuff for read mode")
 		timerSeq = pd.rtSeq
 		pd.rdLock.Lock()
 		defer pd.rdLock.Unlock()
 	} else if mode == ModeWrite {
+		fmt.Println("[nathan debug] setting up stuff for write mode")
 		timerSeq = pd.wtSeq
 		state = &pd.wrState
 		unblockChan = pd.unblockWr
@@ -133,8 +138,10 @@ wait:
 	for {
 		select {
 		case <-unblockChan:
+			fmt.Println("[nathan debug] unblock chan written to")
 			break wait
 		case <-expiryChan:
+			fmt.Println("[nathan debug] expiry chan written to")
 			pd.lock.Lock()
 			if mode == ModeRead {
 				if timerSeq == pd.rdSeq {
@@ -156,6 +163,7 @@ wait:
 		}
 	}
 	err := pd.checkPollErr(mode)
+	fmt.Println("[nathan debug] wait end")
 	return err
 }
 
@@ -205,9 +213,19 @@ func (pd *pollDesc) setDeadline(t time.Time, mode PollMode) {
 		}
 		pd.rdDeadline = d
 		if d > 0 {
-			pd.rdTimer.Reset(time.Duration(d))
+			// // blindly copied from docs - start
+			// if pd.rdTimer.Stop() {
+			// 	// timer stopped successfully; it won't have anything in timer.C
+			// } else {
+			// 	// timer already stopped; we better confirm that C has been emptied
+			// 	<-pd.rdTimer.C
+			// }
+			// // blindly copied from the docs - end
+			timeResetReturnValue := pd.rdTimer.Reset(time.Duration(d))
+			fmt.Printf("[nathan debug] finished setting up read deadline timer with duration: %.2f seconds. Timer was previously active: %t \n", time.Duration(d).Seconds(), timeResetReturnValue)
 		}
 		if d < 0 {
+			fmt.Println("[nathan debug] read deadline is in past, so setting read to unblock")
 			pd.unblock(ModeRead, false, false)
 		}
 	}
@@ -219,9 +237,16 @@ func (pd *pollDesc) setDeadline(t time.Time, mode PollMode) {
 		}
 		pd.wdDeadline = d
 		if d > 0 {
-			pd.wdTimer.Reset(time.Duration(d))
+			// // blindly copied from docs - start
+			// if !pd.wdTimer.Stop() {
+			// 	<-pd.wdTimer.C
+			// }
+			// // blindly copied from the docs - end
+			timeResetReturnValue := pd.wdTimer.Reset(time.Duration(d))
+			fmt.Printf("[nathan debug] finished setting up write deadline timer with duration: %.2f seconds. Timer was previously active: %t \n", time.Duration(d).Seconds(), timeResetReturnValue)
 		}
 		if d < 0 {
+			fmt.Println("[nathan debug] write deadline is in past, so setting write to unblock")
 			pd.unblock(ModeWrite, false, false)
 		}
 	}

--- a/poll.go
+++ b/poll.go
@@ -20,9 +20,9 @@ const (
 
 type PollMode int
 
-// Issue THREE
+// Issue FOUR
 // The logic in setDeadline needs both ModeWrite and ModeRead to be non-zero.
-// E.G., Previously, setDeadline(modeWrite) is equivelant to setDeadline(modeRead + modeWrite)
+// E.G., Previously, setDeadline(modeWrite) is equivalent to setDeadline(modeRead + modeWrite)
 const (
 	Blah = PollMode(iota)
 	ModeWrite

--- a/read.go
+++ b/read.go
@@ -74,6 +74,8 @@ func (s SrtSocket) ReadPacket(packet *SrtPacket) (n int, err error) {
 
 	n, err = srtRecvMsg2Impl(s.socket, packet.Buffer, (*C.SRT_MSGCTRL)(unsafe.Pointer(&msgctrl)))
 
+	// Issue TWO
+	// This for loop will never break if the deadline has been hit (return value of s.pd.wait(ModeRead))
 	for {
 		if !errors.Is(err, error(EAsyncRCV)) || s.blocking {
 			// this must include when the socket is closed, since I've seen this exit without the below fix

--- a/srtgo.go
+++ b/srtgo.go
@@ -201,6 +201,7 @@ func (s *SrtSocket) Listen(backlog int) error {
 
 // Connect to a remote endpoint
 func (s *SrtSocket) Connect() error {
+	fmt.Println("[nathan debug] socket.Connect start")
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	sa, salen, err := CreateAddrInet(s.host, s.port)
@@ -208,14 +209,20 @@ func (s *SrtSocket) Connect() error {
 		return err
 	}
 
+	fmt.Println("[nathan debug] actual connect start")
 	res := C.srt_connect(s.socket, sa, C.int(salen))
+	fmt.Println("[nathan debug] actual connect end")
 	if res == SRT_ERROR {
+		fmt.Println("[nathan debug] actual connect had SRT error!")
 		C.srt_close(s.socket)
 		return srtGetAndClearError()
 	}
 
+	fmt.Printf("[nathan debug] s.blocking: %t\n", s.blocking)
 	if !s.blocking {
+		fmt.Println("[nathan debug] waiting...")
 		if err := s.pd.wait(ModeWrite); err != nil {
+			fmt.Printf("[nathan debug] waiting had error: %v\n", err)
 			return err
 		}
 	}


### PR DESCRIPTION
As per https://github.com/Haivision/srtgo/pull/63 (and https://github.com/Haivision/srtgo/pull/58)...

Fixes for SetDeadline:

_Issue 1) When the poll descriptor is created, it is with a duration of 0, which causes the deadline timer to fire right away and that's waiting the next time a deadline is set up.
Issue 2) If there is a delay between setting up deadlines, and the timer fired after the poll.Wait() had returned, that timer signal is not cleared from the channel and will cause wait to return immediately.
Issue 3) The return value from poll.Wait() is not checked in the Read and Write functions, which will cause a Read to hang if there is no data on the socket_

Example of 1:
```
socket, socketCreateErr = srtgo.NewSrtSocket(s.host, s.port, s.options)

spa.socket.SetWriteDeadline() // Use deadline

err := socket.Connect() // Will return immediately, because the deadline timer fires immediately. This is the reason this synchroniser test breaks: TestMpegTSContextReadRawSRTRTPPacketsMultiInput
```

Example of 3:
```
socket, socketCreateErr = srtgo.NewSrtSocket(s.host, s.port, s.options)
err := socket.Connect()

socket.ReadPacket(srtPacket) // Will wait forever, because there isn't actually a check if the deadline has been met.
```

---

As per my experiments...

Issue 4) `SetWriteDeadline` is currently equivalent to both `SetReadDeadline` and `SetWriteDeadline`, due to a silly mistake.

---

TODO:
- Confirm it works
    - Use SetWriteDeadline before Connect in srtsocket.go
    - Use SetReadDeadline before ReadPackets in srtsocket.go
    - Confirm tests work: `TestMpegTSContextReadRawSRTRTPPacketsMultiInput` and `TestInputStreamRecorderSrtStream`
- Remove temp comments and logs